### PR TITLE
Validate capy.yaml step payloads before execution

### DIFF
--- a/src/capy_config.py
+++ b/src/capy_config.py
@@ -1,0 +1,34 @@
+from typing import List, Literal, Optional
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class CapyStep(BaseModel):
+    """capy.yaml step"""
+
+    type: Literal["bash", "create-env", "instruction", "wait"] = Field(
+        description="Type of step to execute"
+    )
+    command: Optional[str] = None
+    text: Optional[str] = None
+    seconds: Optional[int] = None
+
+    @model_validator(mode="after")
+    def validate_step_payload(self) -> "CapyStep":
+        """Reject capy.yaml steps that would fail later during setup."""
+        if self.type == "bash" and not (self.command and self.command.strip()):
+            raise ValueError("bash steps require a non-empty command")
+
+        if self.type == "instruction" and not (self.text and self.text.strip()):
+            raise ValueError("instruction steps require non-empty text")
+
+        if self.type == "wait" and self.seconds is not None and self.seconds <= 0:
+            raise ValueError("wait steps require seconds to be greater than 0")
+
+        return self
+
+
+class CapyConfig(BaseModel):
+    """capy.yaml config"""
+
+    steps: List[CapyStep]

--- a/src/models.py
+++ b/src/models.py
@@ -1,27 +1,10 @@
 from typing import List, Literal, Optional
-from pydantic import BaseModel, Field, ConfigDict
+from pydantic import BaseModel, ConfigDict
 from scrapybara.client import Step
 from .generate.models import TestCase
 from .execute.models import TestResult as BaseTestResult
+from .capy_config import CapyConfig, CapyStep
 from datetime import datetime
-
-
-# capy.yaml
-class CapyStep(BaseModel):
-    """capy.yaml step"""
-
-    type: Literal["bash", "create-env", "instruction", "wait"] = Field(
-        description="Type of step to execute"
-    )
-    command: Optional[str] = None
-    text: Optional[str] = None
-    seconds: Optional[int] = None
-
-
-class CapyConfig(BaseModel):
-    """capy.yaml config"""
-
-    steps: List[CapyStep]
 
 
 # Review

--- a/tests/test_capy_config.py
+++ b/tests/test_capy_config.py
@@ -1,0 +1,45 @@
+import pytest
+from pydantic import ValidationError
+
+from src.capy_config import CapyConfig
+
+
+def test_accepts_valid_capy_steps():
+    config = CapyConfig.model_validate(
+        {
+            "steps": [
+                {"type": "bash", "command": "npm install"},
+                {"type": "create-env"},
+                {"type": "instruction", "text": "Open http://localhost:3000"},
+                {"type": "wait", "seconds": 5},
+                {"type": "wait"},
+            ]
+        }
+    )
+
+    assert len(config.steps) == 5
+
+
+@pytest.mark.parametrize(
+    ("step", "message"),
+    [
+        ({"type": "bash"}, "bash steps require a non-empty command"),
+        ({"type": "bash", "command": "   "}, "bash steps require a non-empty command"),
+        ({"type": "instruction"}, "instruction steps require non-empty text"),
+        (
+            {"type": "instruction", "text": ""},
+            "instruction steps require non-empty text",
+        ),
+        (
+            {"type": "wait", "seconds": 0},
+            "wait steps require seconds to be greater than 0",
+        ),
+        (
+            {"type": "wait", "seconds": -1},
+            "wait steps require seconds to be greater than 0",
+        ),
+    ],
+)
+def test_rejects_invalid_capy_steps(step, message):
+    with pytest.raises(ValidationError, match=message):
+        CapyConfig.model_validate({"steps": [step]})


### PR DESCRIPTION
## Summary

`capy.yaml` steps are currently typed by step kind, but the payload fields are all optional. That means invalid setup config can get accepted and then fail later inside the execution path:

- `bash` without `command`
- `instruction` without `text`
- `wait` with `seconds <= 0`

This PR moves `CapyStep` / `CapyConfig` into a small dependency-light `src/capy_config.py` module, re-exports the models from `src.models` for existing imports, and adds Pydantic validation for those step-specific payload requirements.

## Why

CodeCapy runs agent setup in remote Scrapybara instances and updates PR comments as it goes. Invalid setup config should fail fast with a clear validation error before an agent session starts, rather than surfacing as a later runtime failure while setting up a PR environment.

## Tests

- `PYTHONPATH=. /Users/ritwij/Library/Python/3.9/bin/uv run --python 3.11 --with pytest --with pydantic pytest tests/test_capy_config.py -q`
- `PYTHONPATH=. /Users/ritwij/Library/Python/3.9/bin/uv run --python 3.11 --with black black --check src/capy_config.py src/models.py tests/test_capy_config.py`
- `PYTHONPATH=. /Users/ritwij/Library/Python/3.9/bin/uv run --python 3.11 python -m compileall src tests`
- `git diff --check`
